### PR TITLE
Update branding, fix emails, replace private beta with App Store

### DIFF
--- a/blog/50-50-custody-myth-equal-time-not-always-equal.html
+++ b/blog/50-50-custody-myth-equal-time-not-always-equal.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/age-appropriate-custody-schedules-guide.html
+++ b/blog/age-appropriate-custody-schedules-guide.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/biff-method-co-parenting-communication.html
+++ b/blog/biff-method-co-parenting-communication.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/child-refuses-visitation-other-parent-house-what-to-do.html
+++ b/blog/child-refuses-visitation-other-parent-house-what-to-do.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/child-support-modifications-when-how-request-changes.html
+++ b/blog/child-support-modifications-when-how-request-changes.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/children-fear-abandonment-divorce.html
+++ b/blog/children-fear-abandonment-divorce.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/children-wellbeing-divorce-research.html
+++ b/blog/children-wellbeing-divorce-research.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/co-parenting-communication-boundaries.html
+++ b/blog/co-parenting-communication-boundaries.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/co-parenting-communication-channels.html
+++ b/blog/co-parenting-communication-channels.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/co-parenting-documentation-guide.html
+++ b/blog/co-parenting-documentation-guide.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/co-parenting-expenses-when-one-parent-earns-more.html
+++ b/blog/co-parenting-expenses-when-one-parent-earns-more.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/co-parenting-spectrum-finding-balance.html
+++ b/blog/co-parenting-spectrum-finding-balance.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/co-parenting-vs-parallel-parenting.html
+++ b/blog/co-parenting-vs-parallel-parenting.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/consistent-rules-across-two-homes-co-parenting.html
+++ b/blog/consistent-rules-across-two-homes-co-parenting.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/counter-parenting-signs-solutions.html
+++ b/blog/counter-parenting-signs-solutions.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/creating-first-co-parenting-plan-essential-elements.html
+++ b/blog/creating-first-co-parenting-plan-essential-elements.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/custody-schedules-special-needs-children.html
+++ b/blog/custody-schedules-special-needs-children.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/essential-first-steps-beginning-co-parenting-journey.html
+++ b/blog/essential-first-steps-beginning-co-parenting-journey.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/ex-starts-dating-helping-kids-navigate-new-relationships.html
+++ b/blog/ex-starts-dating-helping-kids-navigate-new-relationships.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/fatal-flaw-co-parenting-apps-what-actually-works.html
+++ b/blog/fatal-flaw-co-parenting-apps-what-actually-works.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/finding-a-therapist-who-understands-high-conflict-co-parenting.html
+++ b/blog/finding-a-therapist-who-understands-high-conflict-co-parenting.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/gift-giving-special-occasions-blended-families.html
+++ b/blog/gift-giving-special-occasions-blended-families.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/gray-rock-method-coparenting.html
+++ b/blog/gray-rock-method-coparenting.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/handling-co-parenting-schedule-changes-without-conflict.html
+++ b/blog/handling-co-parenting-schedule-changes-without-conflict.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/helping-your-child-bond-with-a-stepparent-without-forcing-it.html
+++ b/blog/helping-your-child-bond-with-a-stepparent-without-forcing-it.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/hidden-realities-co-parenting-no-one-warns-you-about.html
+++ b/blog/hidden-realities-co-parenting-no-one-warns-you-about.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/hidden-truths-about-coparenting-no-one-tells-you.html
+++ b/blog/hidden-truths-about-coparenting-no-one-tells-you.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/holiday-custody-schedules-fair-traditions-both-homes.html
+++ b/blog/holiday-custody-schedules-fair-traditions-both-homes.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-parental-conflict-affects-children-s-relationships-later-in-life.html
+++ b/blog/how-parental-conflict-affects-children-s-relationships-later-in-life.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-build-a-communication-record-that-protects-you.html
+++ b/blog/how-to-build-a-communication-record-that-protects-you.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-choose-a-family-law-attorney-for-a-high-conflict-custody-case.html
+++ b/blog/how-to-choose-a-family-law-attorney-for-a-high-conflict-custody-case.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-co-parent-when-you-re-afraid-of-your-ex.html
+++ b/blog/how-to-co-parent-when-you-re-afraid-of-your-ex.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-co-parent-when-your-ex-remarries.html
+++ b/blog/how-to-co-parent-when-your-ex-remarries.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-co-parent-when-your-ex-s-new-partner-gets-involved-in-your-co-parenting.html
+++ b/blog/how-to-co-parent-when-your-ex-s-new-partner-gets-involved-in-your-co-parenting.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-co-parent-with-a-narcissist.html
+++ b/blog/how-to-co-parent-with-a-narcissist.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-co-parent-with-someone-who-uses-email-as-a-weapon.html
+++ b/blog/how-to-co-parent-with-someone-who-uses-email-as-a-weapon.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-co-parent-with-someone-who-won-t-cooperate.html
+++ b/blog/how-to-co-parent-with-someone-who-won-t-cooperate.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-communicate-with-a-high-conflict-co-parent.html
+++ b/blog/how-to-communicate-with-a-high-conflict-co-parent.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-cope-on-the-days-you-don-t-have-your-kids.html
+++ b/blog/how-to-cope-on-the-days-you-don-t-have-your-kids.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-deal-with-a-co-parent-who-breaks-agreements.html
+++ b/blog/how-to-deal-with-a-co-parent-who-breaks-agreements.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-handle-a-co-parent-who-threatens-to-take-you-to-court.html
+++ b/blog/how-to-handle-a-co-parent-who-threatens-to-take-you-to-court.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-handle-child-extracurricular-activity-costs-co-parenting.html
+++ b/blog/how-to-handle-child-extracurricular-activity-costs-co-parenting.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-handle-false-accusations-from-your-co-parent.html
+++ b/blog/how-to-handle-false-accusations-from-your-co-parent.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-handle-holidays-and-events-with-a-blended-family.html
+++ b/blog/how-to-handle-holidays-and-events-with-a-blended-family.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-handle-last-minute-custody-schedule-changes.html
+++ b/blog/how-to-handle-last-minute-custody-schedule-changes.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-handle-medical-expenses-in-co-parenting.html
+++ b/blog/how-to-handle-medical-expenses-in-co-parenting.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-handle-teacher-conferences-school-events-co-parenting.html
+++ b/blog/how-to-handle-teacher-conferences-school-events-co-parenting.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-handle-transitions-and-drop-offs-with-a-high-conflict-co-parent.html
+++ b/blog/how-to-handle-transitions-and-drop-offs-with-a-high-conflict-co-parent.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-help-your-child-adjust-to-two-homes.html
+++ b/blog/how-to-help-your-child-adjust-to-two-homes.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-introduce-co-parenting-rules-to-children-age-guide.html
+++ b/blog/how-to-introduce-co-parenting-rules-to-children-age-guide.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-keep-co-parenting-conversations-focused-on-the-kids.html
+++ b/blog/how-to-keep-co-parenting-conversations-focused-on-the-kids.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-make-a-custody-schedule-that-actually-works.html
+++ b/blog/how-to-make-a-custody-schedule-that-actually-works.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-modify-a-custody-agreement-when-and-how.html
+++ b/blog/how-to-modify-a-custody-agreement-when-and-how.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-protect-your-children-from-co-parenting-conflict.html
+++ b/blog/how-to-protect-your-children-from-co-parenting-conflict.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-protect-yourself-from-gaslighting-in-co-parenting.html
+++ b/blog/how-to-protect-yourself-from-gaslighting-in-co-parenting.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-respond-to-a-hostile-co-parenting-message.html
+++ b/blog/how-to-respond-to-a-hostile-co-parenting-message.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-set-boundaries-in-co-parent-communication.html
+++ b/blog/how-to-set-boundaries-in-co-parent-communication.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-split-expenses-with-your-co-parent-without-fighting.html
+++ b/blog/how-to-split-expenses-with-your-co-parent-without-fighting.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-stop-co-parenting-arguments-over-text.html
+++ b/blog/how-to-stop-co-parenting-arguments-over-text.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-stop-co-parenting-conflict-from-taking-over-your-life.html
+++ b/blog/how-to-stop-co-parenting-conflict-from-taking-over-your-life.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-stop-your-co-parent-from-controlling-you-through-the-kids.html
+++ b/blog/how-to-stop-your-co-parent-from-controlling-you-through-the-kids.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/how-to-talk-to-your-kids-about-the-divorce-at-every-age.html
+++ b/blog/how-to-talk-to-your-kids-about-the-divorce-at-every-age.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/is-it-time-making-the-hard-decision-about-your-marriage.html
+++ b/blog/is-it-time-making-the-hard-decision-about-your-marriage.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/is-it-time-navigating-whether-to-stay-or-go.html
+++ b/blog/is-it-time-navigating-whether-to-stay-or-go.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/managing-anxiety-when-you-can-t-control-what-happens-at-the-other-house.html
+++ b/blog/managing-anxiety-when-you-can-t-control-what-happens-at-the-other-house.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/mindset-shift-divorced-coparents.html
+++ b/blog/mindset-shift-divorced-coparents.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/parallel-parenting-vs-co-parenting-what-s-the-difference.html
+++ b/blog/parallel-parenting-vs-co-parenting-what-s-the-difference.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/rebuilding-your-identity-after-divorce.html
+++ b/blog/rebuilding-your-identity-after-divorce.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/relocation-after-divorce-what-you-need-to-know-before-you-move.html
+++ b/blog/relocation-after-divorce-what-you-need-to-know-before-you-move.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/requesting-schedule-swaps-work-travel-strategic-approach.html
+++ b/blog/requesting-schedule-swaps-work-travel-strategic-approach.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/signs-your-child-is-struggling-with-the-divorce-and-what-to-do.html
+++ b/blog/signs-your-child-is-struggling-with-the-divorce-and-what-to-do.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/signs-your-co-parenting-situation-is-improving-even-when-it-doesn-t-feel-like-it.html
+++ b/blog/signs-your-co-parenting-situation-is-improving-even-when-it-doesn-t-feel-like-it.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/surprising-benefits-of-co-parenting-better-than-you-think.html
+++ b/blog/surprising-benefits-of-co-parenting-better-than-you-think.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/the-48-hour-rule-why-waiting-before-responding-changes-everything.html
+++ b/blog/the-48-hour-rule-why-waiting-before-responding-changes-everything.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/the-emotional-toll-of-co-parenting-with-a-difficult-ex.html
+++ b/blog/the-emotional-toll-of-co-parenting-with-a-difficult-ex.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/the-stepparent-s-role-in-co-parenting-boundaries-that-work.html
+++ b/blog/the-stepparent-s-role-in-co-parenting-boundaries-that-work.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/timing-your-divorce-when-to-consider-separation-around-life-events.html
+++ b/blog/timing-your-divorce-when-to-consider-separation-around-life-events.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/tone-in-text-co-parenting.html
+++ b/blog/tone-in-text-co-parenting.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/unexpected-silver-linings-hidden-benefits-co-parenting.html
+++ b/blog/unexpected-silver-linings-hidden-benefits-co-parenting.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/what-counts-as-a-shared-expense-in-co-parenting.html
+++ b/blog/what-counts-as-a-shared-expense-in-co-parenting.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/what-counts-as-high-conflict-co-parenting.html
+++ b/blog/what-counts-as-high-conflict-co-parenting.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/what-happens-when-you-violate-custody-order-legal-consequences.html
+++ b/blog/what-happens-when-you-violate-custody-order-legal-consequences.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/what-is-a-guardian-ad-litem-and-what-do-they-do.html
+++ b/blog/what-is-a-guardian-ad-litem-and-what-do-they-do.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/what-is-a-parenting-plan-and-do-you-need-one.html
+++ b/blog/what-is-a-parenting-plan-and-do-you-need-one.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/what-is-contempt-of-court-in-custody-cases.html
+++ b/blog/what-is-contempt-of-court-in-custody-cases.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/what-is-structured-co-parenting-communication.html
+++ b/blog/what-is-structured-co-parenting-communication.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/what-makes-co-parenting-communication-actually-work.html
+++ b/blog/what-makes-co-parenting-communication-actually-work.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/what-to-do-when-your-co-parent-badmouths-you-to-the-kids.html
+++ b/blog/what-to-do-when-your-co-parent-badmouths-you-to-the-kids.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/what-to-do-when-your-co-parent-brings-up-the-past-in-every-conversation.html
+++ b/blog/what-to-do-when-your-co-parent-brings-up-the-past-in-every-conversation.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/what-to-do-when-your-co-parent-refuses-to-communicate.html
+++ b/blog/what-to-do-when-your-co-parent-refuses-to-communicate.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/what-to-expect-in-family-court-a-co-parent-s-guide.html
+++ b/blog/what-to-expect-in-family-court-a-co-parent-s-guide.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/what-your-kids-experience-when-co-parents-can-t-communicate.html
+++ b/blog/what-your-kids-experience-when-co-parents-can-t-communicate.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/what-your-teenager-needs-from-you-during-and-after-divorce.html
+++ b/blog/what-your-teenager-needs-from-you-during-and-after-divorce.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/when-child-asks-which-parent-they-love-more.html
+++ b/blog/when-child-asks-which-parent-they-love-more.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/when-co-parenting-conflict-won-t-stop-knowing-when-to-get-help.html
+++ b/blog/when-co-parenting-conflict-won-t-stop-knowing-when-to-get-help.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/when-to-divorce-timing-separation-around-life-events.html
+++ b/blog/when-to-divorce-timing-separation-around-life-events.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/when-your-child-has-a-new-sibling-at-the-other-house.html
+++ b/blog/when-your-child-has-a-new-sibling-at-the-other-house.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/when-your-child-says-they-don-t-want-to-go-to-the-other-parent-s-house.html
+++ b/blog/when-your-child-says-they-don-t-want-to-go-to-the-other-parent-s-house.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/when-your-co-parent-undermines-your-parenting.html
+++ b/blog/when-your-co-parent-undermines-your-parenting.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/when-your-co-parent-uses-the-kids-as-messengers.html
+++ b/blog/when-your-co-parent-uses-the-kids-as-messengers.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/blog/why-co-parenting-feels-harder-than-it-should.html
+++ b/blog/why-co-parenting-feels-harder-than-it-should.html
@@ -130,7 +130,7 @@
 
   <a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-nav">
-  <a href="/" class="nav-logo">Clearly</a>
+  <a href="/" class="nav-logo">Clearly.</a>
   <div class="nav-right">
     <a href="/blog.html" class="nav-link">Common Ground</a>
     <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/communication-styles/index.html
+++ b/communication-styles/index.html
@@ -601,7 +601,7 @@
     <!-- Navigation -->
     <nav class="assessment-nav">
       <div class="container">
-        <a href="/" class="assessment-nav-brand">Clearly</a>
+        <a href="/" class="assessment-nav-brand">Clearly.</a>
       </div>
     </nav>
 
@@ -736,11 +736,10 @@
             <p>The patterns you just explored? Clearly is designed to help you navigate them—every conversation, not just this assessment.</p>
             <p>Topic-based discussions that move toward decisions. AI-assisted rewrites when emotions run high. Structure that keeps things focused on what matters—not who's right.</p>
             <p style="font-weight: 500; color: var(--text); margin-bottom: 28px;">It's a co-parenting app built around the same principles you just learned.</p>
-            <a href="/" class="btn-primary">
-              See how Clearly works
+            <a href="https://apps.apple.com/us/app/clearly-co-parenting-resolved/id6758027374" class="btn-primary">
+              Download on the App Store
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="5" y1="12" x2="19" y2="12"></line><polyline points="12 5 19 12 12 19"></polyline></svg>
             </a>
-            <a href="#" class="btn-text" data-access-modal style="display: block; margin-top: 16px; color: var(--text-secondary); font-size: 14px;">Download on the App Store</a>
           </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -850,7 +850,7 @@
   <!-- Header -->
   <a href="#main-content" class="skip-link">Skip to content</a>
   <header class="site-nav">
-    <a href="/" class="nav-logo">Clearly</a>
+    <a href="/" class="nav-logo">Clearly.</a>
     <div class="nav-right">
       <a href="/blog.html" class="nav-link">Common Ground</a>
       <a href="/professionals.html" class="nav-link">For Professionals</a>

--- a/supabase/functions/alignment-signup/index.ts
+++ b/supabase/functions/alignment-signup/index.ts
@@ -558,7 +558,7 @@ async function sendPlanEmail(data: NormalizedData, viewToken: string, familyCode
   <div style="max-width: 560px; margin: 0 auto; padding: 40px 20px;">
 
     <div style="text-align: center; margin-bottom: 32px;">
-      <img src="https://dwncravjhkbclbuzijra.supabase.co/storage/v1/object/public/Clearly%20Logos/icon.png" alt="Clearly" width="48" height="48">
+      <img src="https://dwncravjhkbclbuzijra.supabase.co/storage/v1/object/public/Clearly%20Logos/default.png" alt="Clearly." width="48" height="48" style="border-radius: 12px;">
     </div>
 
     <p style="color: #5C5856; font-size: 16px; line-height: 1.7;">
@@ -589,7 +589,7 @@ async function sendPlanEmail(data: NormalizedData, viewToken: string, familyCode
 
     <div style="border-top: 1px solid #E8E6E4; margin-top: 36px; padding-top: 28px;">
       <p style="color: #5C5856; font-size: 15px; line-height: 1.8;">
-        We're building Clearly—a co-parenting app designed to make day-to-day coordination easier. It's currently in private beta. <a href="https://getclearly.app" style="color: #0D8268;">Request early access</a>.
+        Clearly is a co-parenting app designed to make day-to-day coordination easier. <a href="https://apps.apple.com/us/app/clearly-co-parenting-resolved/id6758027374" style="color: #0D8268;">Download it on the App Store</a>.
       </p>
     </div>
 
@@ -625,6 +625,10 @@ async function sendPlanEmail(data: NormalizedData, viewToken: string, familyCode
       from: 'Clearly <hello@getclearly.app>',
       to: [data.email],
       subject: 'Your Co-Parenting Alignment Plan',
+      headers: {
+        'List-Unsubscribe': '<mailto:hello@getclearly.app?subject=Unsubscribe>',
+        'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click'
+      },
       html: emailHtml
     }
 
@@ -685,7 +689,7 @@ async function sendComparisonEmail(data: NormalizedData, familyCode: string, lin
   <div style="max-width: 560px; margin: 0 auto; padding: 40px 20px;">
 
     <div style="text-align: center; margin-bottom: 32px;">
-      <img src="https://dwncravjhkbclbuzijra.supabase.co/storage/v1/object/public/Clearly%20Logos/icon.png" alt="Clearly" width="48" height="48">
+      <img src="https://dwncravjhkbclbuzijra.supabase.co/storage/v1/object/public/Clearly%20Logos/default.png" alt="Clearly." width="48" height="48" style="border-radius: 12px;">
     </div>
 
     <p style="color: #5C5856; font-size: 16px; line-height: 1.7;">
@@ -736,6 +740,10 @@ async function sendComparisonEmail(data: NormalizedData, familyCode: string, lin
         from: 'Clearly <hello@getclearly.app>',
         to: [data.email],
         subject: 'Your Co-Parenting Alignment Comparison is Ready',
+        headers: {
+          'List-Unsubscribe': '<mailto:hello@getclearly.app?subject=Unsubscribe>',
+          'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click'
+        },
         html: emailHtml
       })
     })
@@ -764,7 +772,7 @@ async function sendComparisonEmailToFirstParent(firstParent: { email: string; pa
   <div style="max-width: 560px; margin: 0 auto; padding: 40px 20px;">
 
     <div style="text-align: center; margin-bottom: 32px;">
-      <img src="https://dwncravjhkbclbuzijra.supabase.co/storage/v1/object/public/Clearly%20Logos/icon.png" alt="Clearly" width="48" height="48">
+      <img src="https://dwncravjhkbclbuzijra.supabase.co/storage/v1/object/public/Clearly%20Logos/default.png" alt="Clearly." width="48" height="48" style="border-radius: 12px;">
     </div>
 
     <p style="color: #5C5856; font-size: 16px; line-height: 1.7;">
@@ -815,6 +823,10 @@ async function sendComparisonEmailToFirstParent(firstParent: { email: string; pa
         from: 'Clearly <hello@getclearly.app>',
         to: [firstParent.email],
         subject: 'Your Co-Parenting Alignment Comparison is Ready',
+        headers: {
+          'List-Unsubscribe': '<mailto:hello@getclearly.app?subject=Unsubscribe>',
+          'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click'
+        },
         html: emailHtml
       })
     })

--- a/supabase/functions/assessment-signup/index.ts
+++ b/supabase/functions/assessment-signup/index.ts
@@ -147,7 +147,7 @@ async function sendResultsEmail(email: string, styleResult: string, secondarySty
 
     <!-- Logo -->
     <div style="text-align: center; margin-bottom: 32px;">
-      <img src="https://dwncravjhkbclbuzijra.supabase.co/storage/v1/object/public/Clearly%20Logos/icon.png" alt="Clearly" width="48" height="48">
+      <img src="https://dwncravjhkbclbuzijra.supabase.co/storage/v1/object/public/Clearly%20Logos/default.png" alt="Clearly." width="48" height="48" style="border-radius: 12px;">
     </div>
 
     <!-- Opening -->
@@ -193,10 +193,10 @@ async function sendResultsEmail(email: string, styleResult: string, secondarySty
     <!-- Soft CTA -->
     <div style="border-top: 1px solid #E8E6E4; margin-top: 36px; padding-top: 28px;">
       <p style="color: #5C5856; font-size: 15px; line-height: 1.8;">
-        We're building Clearly—a co-parenting app designed around these same principles. Topic-based conversations that resolve. Structure that makes the day-to-day easier.
+        Clearly is a co-parenting app designed around these same principles. Topic-based conversations that resolve. Structure that makes the day-to-day easier.
       </p>
       <p style="color: #5C5856; font-size: 15px; line-height: 1.8;">
-        It's currently in private beta. If you'd like early access, you can <a href="https://getclearly.app" style="color: #0D8268;">request it here</a>.
+        <a href="https://apps.apple.com/us/app/clearly-co-parenting-resolved/id6758027374" style="color: #0D8268;">Download Clearly on the App Store</a> and start putting these principles into practice.
       </p>
     </div>
 
@@ -233,6 +233,10 @@ async function sendResultsEmail(email: string, styleResult: string, secondarySty
         from: 'Clearly <hello@getclearly.app>',
         to: [email],
         subject: `Your co-parenting communication style: ${style.name}`,
+        headers: {
+          'List-Unsubscribe': '<mailto:hello@getclearly.app?subject=Unsubscribe>',
+          'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click'
+        },
         html: emailHtml
       })
     })

--- a/supabase/functions/create-plan-template/index.ts
+++ b/supabase/functions/create-plan-template/index.ts
@@ -364,6 +364,10 @@ serve(async (req) => {
             from: "Clearly <hello@getclearly.app>",
             to: data.email,
             subject: `Your Clearly Family Code: ${planTemplate.share_code}`,
+            headers: {
+              "List-Unsubscribe": "<mailto:hello@getclearly.app?subject=Unsubscribe>",
+              "List-Unsubscribe-Post": "List-Unsubscribe=One-Click"
+            },
             html: `
 <!DOCTYPE html>
 <html>
@@ -376,7 +380,7 @@ serve(async (req) => {
 
     <!-- Logo -->
     <div style="text-align: center; margin-bottom: 40px;">
-      <img src="https://dwncravjhkbclbuzijra.supabase.co/storage/v1/object/public/Clearly%20Logos/icon.png" alt="Clearly" width="56" height="56" style="width: 56px; height: 56px; border-radius: 14px;">
+      <img src="https://dwncravjhkbclbuzijra.supabase.co/storage/v1/object/public/Clearly%20Logos/default.png" alt="Clearly." width="56" height="56" style="width: 56px; height: 56px; border-radius: 14px;">
     </div>
 
     <!-- Main Card -->

--- a/supabase/functions/professional-signup/index.ts
+++ b/supabase/functions/professional-signup/index.ts
@@ -49,17 +49,19 @@ serve(async (req) => {
     const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
     // Insert into professionals table
+    const insertData: Record<string, unknown> = {
+      email: email.toLowerCase().trim(),
+      role_type: role_type?.trim() || null,
+      feature_interests: feature_interests || null,
+      notes: notes?.trim() || null
+    };
+    if (name?.trim()) insertData.name = name.trim();
+    if (profession_type?.trim()) insertData.profession_type = profession_type.trim();
+    if (organization?.trim()) insertData.organization = organization.trim();
+
     const { data, error: dbError } = await supabase
       .from("z_professionals")
-      .insert({
-        email: email.toLowerCase().trim(),
-        name: name?.trim() || null,
-        profession_type: profession_type?.trim() || null,
-        organization: organization?.trim() || null,
-        role_type: role_type?.trim() || null,
-        feature_interests: feature_interests || null,
-        notes: notes?.trim() || null
-      })
+      .insert(insertData)
       .select()
       .single();
 
@@ -98,6 +100,10 @@ serve(async (req) => {
             from: "Clearly <hello@getclearly.app>",
             to: email,
             subject: "Welcome to Clearly — For Professionals",
+            headers: {
+              "List-Unsubscribe": "<mailto:hello@getclearly.app?subject=Unsubscribe>",
+              "List-Unsubscribe-Post": "List-Unsubscribe=One-Click"
+            },
             html: `
 <!DOCTYPE html>
 <html>
@@ -112,40 +118,40 @@ serve(async (req) => {
 
     <!-- Logo -->
     <div style="text-align: center; margin-bottom: 32px;">
-      <img src="https://dwncravjhkbclbuzijra.supabase.co/storage/v1/object/public/Clearly%20Logos/icon.png" alt="Clearly" width="48" height="48">
+      <img src="https://dwncravjhkbclbuzijra.supabase.co/storage/v1/object/public/Clearly%20Logos/default.png" alt="Clearly." width="48" height="48" style="border-radius: 12px;">
     </div>
 
     <!-- Opening -->
     <p style="color: #5C5856; font-size: 16px; line-height: 1.7;">
-      Thank you for your interest in Clearly. We're building with legal and family professionals in mind.
+      Thank you for your interest in Clearly. We built it with legal and family professionals in mind.
     </p>
 
     <!-- Main Card -->
     <div style="background: white; border: 1px solid #E8E6E4; border-radius: 12px; padding: 28px; margin: 28px 0;">
       <p style="font-size: 13px; color: #0D8268; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; margin: 0 0 8px 0;">For Professionals</p>
       <h2 style="font-size: 24px; color: #1A1917; margin: 0 0 16px 0;">Clear, time-stamped, professionally reviewable records.</h2>
-      <p style="font-size: 15px; color: #5C5856; margin: 0;">We'll notify you when we launch so you can see how Clearly can help your clients.</p>
+      <p style="font-size: 15px; color: #5C5856; margin: 0;">Clearly produces structured communication records that are ready for professional review, mediation, and court processes.</p>
     </div>
 
-    <!-- What's coming -->
-    <h3 style="font-size: 16px; color: #1A1917; margin: 28px 0 12px 0;">What we're building</h3>
+    <!-- What's included -->
+    <h3 style="font-size: 16px; color: #1A1917; margin: 28px 0 12px 0;">What Clearly provides</h3>
     <p style="color: #5C5856; font-size: 15px; line-height: 1.8;">
       • Streamlined record review and export tools<br>
       • Complete communication history with timestamps<br>
       • Custody calendar documentation<br>
       • Expense tracking with receipt attachments<br>
-      • Professional resources and best practices
+      • PDF exports for court and mediation
     </p>
 
     <!-- CTA -->
     <div style="background: #E6F5F1; border-radius: 12px; padding: 24px; margin: 28px 0;">
-      <h3 style="font-size: 16px; color: #0D8268; margin: 0 0 12px 0; text-align: center;">Learn more</h3>
+      <h3 style="font-size: 16px; color: #0D8268; margin: 0 0 12px 0; text-align: center;">Try Clearly</h3>
       <p style="color: #1A1917; font-size: 15px; line-height: 1.8; margin: 0 0 16px 0; text-align: center;">
-        See what we're building for legal and family professionals.
+        Download the app and see how it can help your clients.
       </p>
       <div style="text-align: center;">
-        <a href="https://getclearly.app/professionals.html" style="display: inline-block; background: #0D8268; color: #ffffff; text-decoration: none; font-weight: 600; font-size: 15px; padding: 12px 24px; border-radius: 8px;">
-          For Professionals
+        <a href="https://apps.apple.com/us/app/clearly-co-parenting-resolved/id6758027374" style="display: inline-block; background: #0D8268; color: #ffffff; text-decoration: none; font-weight: 600; font-size: 15px; padding: 12px 24px; border-radius: 8px;">
+          Download on the App Store
         </a>
       </div>
     </div>

--- a/supabase/functions/waitlist-signup/index.ts
+++ b/supabase/functions/waitlist-signup/index.ts
@@ -89,7 +89,11 @@ serve(async (req) => {
           body: JSON.stringify({
             from: "Clearly <hello@getclearly.app>",
             to: email,
-            subject: "You're on the list — We'll be in touch",
+            subject: "Welcome to Clearly — A calmer way to co-parent",
+            headers: {
+              "List-Unsubscribe": "<mailto:hello@getclearly.app?subject=Unsubscribe>",
+              "List-Unsubscribe-Post": "List-Unsubscribe=One-Click"
+            },
             html: `
 <!DOCTYPE html>
 <html>
@@ -104,14 +108,14 @@ serve(async (req) => {
 
     <!-- Logo -->
     <div style="text-align: center; margin-bottom: 32px;">
-      <img src="https://dwncravjhkbclbuzijra.supabase.co/storage/v1/object/public/Clearly%20Logos/icon.png" alt="Clearly" width="48" height="48">
+      <img src="https://dwncravjhkbclbuzijra.supabase.co/storage/v1/object/public/Clearly%20Logos/default.png" alt="Clearly." width="48" height="48" style="border-radius: 12px;">
     </div>
 
     <!-- Main Card -->
     <div style="background: white; border: 1px solid #E8E6E4; border-radius: 12px; padding: 28px; margin: 0 0 28px 0;">
-      <h1 style="font-size: 26px; color: #1A1917; margin: 0 0 16px 0; text-align: center;">You're on the list.</h1>
+      <h1 style="font-size: 26px; color: #1A1917; margin: 0 0 16px 0; text-align: center;">Thanks for your interest in Clearly.</h1>
       <p style="color: #5C5856; font-size: 16px; line-height: 1.7; margin: 0; text-align: center;">
-        We're opening access gradually and will send you an invite when it's your turn.
+        Clearly is available now on the App Store. Download it and start co-parenting with less conflict.
       </p>
     </div>
 
@@ -132,15 +136,15 @@ serve(async (req) => {
       </p>
     </div>
 
-    <!-- Blog CTA -->
-    <p style="color: #5C5856; font-size: 15px; line-height: 1.8; margin: 0 0 16px 0; text-align: center;">
-      While you wait, our blog has practical advice for navigating co-parenting.
-    </p>
-    <div style="text-align: center;">
-      <a href="https://getclearly.app/blog.html" style="display: inline-block; background: #0D8268; color: #ffffff; text-decoration: none; font-weight: 600; font-size: 15px; padding: 12px 24px; border-radius: 8px;">
-        Read Common Ground
+    <!-- App Store CTA -->
+    <div style="text-align: center; margin: 0 0 16px 0;">
+      <a href="https://apps.apple.com/us/app/clearly-co-parenting-resolved/id6758027374" style="display: inline-block; background: #0D8268; color: #ffffff; text-decoration: none; font-weight: 600; font-size: 15px; padding: 12px 24px; border-radius: 8px;">
+        Download on the App Store
       </a>
     </div>
+    <p style="color: #5C5856; font-size: 15px; line-height: 1.8; margin: 0 0 0 0; text-align: center;">
+      Our blog also has practical advice for navigating co-parenting: <a href="https://getclearly.app/blog.html" style="color: #0D8268;">Read Common Ground</a>
+    </p>
 
     <!-- Sign-off -->
     <div style="margin-top: 36px; text-align: center;">

--- a/supabase/functions/welcome-email/index.ts
+++ b/supabase/functions/welcome-email/index.ts
@@ -70,6 +70,10 @@ serve(async (req) => {
         from: "Clearly <hello@getclearly.app>",
         to: email,
         subject: "Welcome to Clearly — Here's your family code",
+        headers: {
+          "List-Unsubscribe": "<mailto:hello@getclearly.app?subject=Unsubscribe>",
+          "List-Unsubscribe-Post": "List-Unsubscribe=One-Click"
+        },
         html: `
 <!DOCTYPE html>
 <html>
@@ -82,7 +86,7 @@ serve(async (req) => {
 
     <!-- Logo -->
     <div style="text-align: center; margin-bottom: 40px;">
-      <img src="https://dwncravjhkbclbuzijra.supabase.co/storage/v1/object/public/Clearly%20Logos/icon.png" alt="Clearly" width="56" height="56" style="width: 56px; height: 56px; border-radius: 14px;">
+      <img src="https://dwncravjhkbclbuzijra.supabase.co/storage/v1/object/public/Clearly%20Logos/default.png" alt="Clearly." width="56" height="56" style="width: 56px; height: 56px; border-radius: 14px;">
     </div>
 
     <!-- Main Card -->


### PR DESCRIPTION
## Summary
- **Clearly. logo**: Added period to header logo across all 103 pages (blog, tools, landing pages)
- **Communication styles CTA**: Replaced "See how Clearly works" + private beta modal with direct App Store download button
- **Email fixes (6 functions)**: Fixed broken logo (icon.png → default.png), removed "private beta" / "launching soon" language, added App Store CTAs to professional and waitlist emails
- **Professional signup fix**: Fixed function crash caused by inserting into non-existent DB columns
- **Spam prevention**: Added List-Unsubscribe headers to all email templates

## Test plan
- [x] Professional signup form submits successfully (tested via API, returns 200)
- [x] Logo renders correctly (default.png returns 200, icon.png was 400)
- [x] "Clearly." with period confirmed in preview across homepage, professionals, communication-styles pages
- [x] All 6 Supabase Edge Functions deployed and verified
- [ ] Verify emails arrive with correct logo and updated copy
- [ ] Check spam score improvement with List-Unsubscribe headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)