### PR TITLE
Add GA4 App Store click tracking and fix event tracking

### DIFF
--- a/_partials/header.html
+++ b/_partials/header.html
@@ -31,4 +31,14 @@
       siteNavRight.classList.toggle('open');
     });
   }
+  // Track App Store clicks
+  document.addEventListener('click', function(e) {
+    var link = e.target.closest('a[href*="apps.apple.com"]');
+    if (link && typeof gtag === 'function') {
+      gtag('event', 'app_store_click', {
+        link_url: link.href,
+        link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+      });
+    }
+  });
 </script>

--- a/blog.html
+++ b/blog.html
@@ -322,6 +322,16 @@
       siteNavRight.classList.toggle('open');
     });
   }
+  // Track App Store clicks
+  document.addEventListener('click', function(e) {
+    var link = e.target.closest('a[href*="apps.apple.com"]');
+    if (link && typeof gtag === 'function') {
+      gtag('event', 'app_store_click', {
+        link_url: link.href,
+        link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+      });
+    }
+  });
 </script><header class="blog-hero" id="main-content">
     <div class="container">
       <div class="blog-hero-badge">

--- a/blog/50-50-custody-myth-equal-time-not-always-equal.html
+++ b/blog/50-50-custody-myth-equal-time-not-always-equal.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/age-appropriate-custody-schedules-guide.html
+++ b/blog/age-appropriate-custody-schedules-guide.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/biff-method-co-parenting-communication.html
+++ b/blog/biff-method-co-parenting-communication.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/child-refuses-visitation-other-parent-house-what-to-do.html
+++ b/blog/child-refuses-visitation-other-parent-house-what-to-do.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/child-support-modifications-when-how-request-changes.html
+++ b/blog/child-support-modifications-when-how-request-changes.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/children-fear-abandonment-divorce.html
+++ b/blog/children-fear-abandonment-divorce.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/children-wellbeing-divorce-research.html
+++ b/blog/children-wellbeing-divorce-research.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/co-parenting-communication-boundaries.html
+++ b/blog/co-parenting-communication-boundaries.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/co-parenting-communication-channels.html
+++ b/blog/co-parenting-communication-channels.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/co-parenting-documentation-guide.html
+++ b/blog/co-parenting-documentation-guide.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/co-parenting-expenses-when-one-parent-earns-more.html
+++ b/blog/co-parenting-expenses-when-one-parent-earns-more.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/co-parenting-spectrum-finding-balance.html
+++ b/blog/co-parenting-spectrum-finding-balance.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/co-parenting-vs-parallel-parenting.html
+++ b/blog/co-parenting-vs-parallel-parenting.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/consistent-rules-across-two-homes-co-parenting.html
+++ b/blog/consistent-rules-across-two-homes-co-parenting.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/counter-parenting-signs-solutions.html
+++ b/blog/counter-parenting-signs-solutions.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/creating-first-co-parenting-plan-essential-elements.html
+++ b/blog/creating-first-co-parenting-plan-essential-elements.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/custody-schedules-special-needs-children.html
+++ b/blog/custody-schedules-special-needs-children.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/essential-first-steps-beginning-co-parenting-journey.html
+++ b/blog/essential-first-steps-beginning-co-parenting-journey.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/ex-starts-dating-helping-kids-navigate-new-relationships.html
+++ b/blog/ex-starts-dating-helping-kids-navigate-new-relationships.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/fatal-flaw-co-parenting-apps-what-actually-works.html
+++ b/blog/fatal-flaw-co-parenting-apps-what-actually-works.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/finding-a-therapist-who-understands-high-conflict-co-parenting.html
+++ b/blog/finding-a-therapist-who-understands-high-conflict-co-parenting.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/gift-giving-special-occasions-blended-families.html
+++ b/blog/gift-giving-special-occasions-blended-families.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/gray-rock-method-coparenting.html
+++ b/blog/gray-rock-method-coparenting.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/handling-co-parenting-schedule-changes-without-conflict.html
+++ b/blog/handling-co-parenting-schedule-changes-without-conflict.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/helping-your-child-bond-with-a-stepparent-without-forcing-it.html
+++ b/blog/helping-your-child-bond-with-a-stepparent-without-forcing-it.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/hidden-realities-co-parenting-no-one-warns-you-about.html
+++ b/blog/hidden-realities-co-parenting-no-one-warns-you-about.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/hidden-truths-about-coparenting-no-one-tells-you.html
+++ b/blog/hidden-truths-about-coparenting-no-one-tells-you.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/holiday-custody-schedules-fair-traditions-both-homes.html
+++ b/blog/holiday-custody-schedules-fair-traditions-both-homes.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-parental-conflict-affects-children-s-relationships-later-in-life.html
+++ b/blog/how-parental-conflict-affects-children-s-relationships-later-in-life.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-build-a-communication-record-that-protects-you.html
+++ b/blog/how-to-build-a-communication-record-that-protects-you.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-choose-a-family-law-attorney-for-a-high-conflict-custody-case.html
+++ b/blog/how-to-choose-a-family-law-attorney-for-a-high-conflict-custody-case.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-co-parent-when-you-re-afraid-of-your-ex.html
+++ b/blog/how-to-co-parent-when-you-re-afraid-of-your-ex.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-co-parent-when-your-ex-remarries.html
+++ b/blog/how-to-co-parent-when-your-ex-remarries.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-co-parent-when-your-ex-s-new-partner-gets-involved-in-your-co-parenting.html
+++ b/blog/how-to-co-parent-when-your-ex-s-new-partner-gets-involved-in-your-co-parenting.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-co-parent-with-a-narcissist.html
+++ b/blog/how-to-co-parent-with-a-narcissist.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-co-parent-with-someone-who-uses-email-as-a-weapon.html
+++ b/blog/how-to-co-parent-with-someone-who-uses-email-as-a-weapon.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-co-parent-with-someone-who-won-t-cooperate.html
+++ b/blog/how-to-co-parent-with-someone-who-won-t-cooperate.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-communicate-with-a-high-conflict-co-parent.html
+++ b/blog/how-to-communicate-with-a-high-conflict-co-parent.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-cope-on-the-days-you-don-t-have-your-kids.html
+++ b/blog/how-to-cope-on-the-days-you-don-t-have-your-kids.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-deal-with-a-co-parent-who-breaks-agreements.html
+++ b/blog/how-to-deal-with-a-co-parent-who-breaks-agreements.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-handle-a-co-parent-who-threatens-to-take-you-to-court.html
+++ b/blog/how-to-handle-a-co-parent-who-threatens-to-take-you-to-court.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-handle-child-extracurricular-activity-costs-co-parenting.html
+++ b/blog/how-to-handle-child-extracurricular-activity-costs-co-parenting.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-handle-false-accusations-from-your-co-parent.html
+++ b/blog/how-to-handle-false-accusations-from-your-co-parent.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-handle-holidays-and-events-with-a-blended-family.html
+++ b/blog/how-to-handle-holidays-and-events-with-a-blended-family.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-handle-last-minute-custody-schedule-changes.html
+++ b/blog/how-to-handle-last-minute-custody-schedule-changes.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-handle-medical-expenses-in-co-parenting.html
+++ b/blog/how-to-handle-medical-expenses-in-co-parenting.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-handle-teacher-conferences-school-events-co-parenting.html
+++ b/blog/how-to-handle-teacher-conferences-school-events-co-parenting.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-handle-transitions-and-drop-offs-with-a-high-conflict-co-parent.html
+++ b/blog/how-to-handle-transitions-and-drop-offs-with-a-high-conflict-co-parent.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-help-your-child-adjust-to-two-homes.html
+++ b/blog/how-to-help-your-child-adjust-to-two-homes.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-introduce-co-parenting-rules-to-children-age-guide.html
+++ b/blog/how-to-introduce-co-parenting-rules-to-children-age-guide.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-keep-co-parenting-conversations-focused-on-the-kids.html
+++ b/blog/how-to-keep-co-parenting-conversations-focused-on-the-kids.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-make-a-custody-schedule-that-actually-works.html
+++ b/blog/how-to-make-a-custody-schedule-that-actually-works.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-modify-a-custody-agreement-when-and-how.html
+++ b/blog/how-to-modify-a-custody-agreement-when-and-how.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-protect-your-children-from-co-parenting-conflict.html
+++ b/blog/how-to-protect-your-children-from-co-parenting-conflict.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-protect-yourself-from-gaslighting-in-co-parenting.html
+++ b/blog/how-to-protect-yourself-from-gaslighting-in-co-parenting.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-respond-to-a-hostile-co-parenting-message.html
+++ b/blog/how-to-respond-to-a-hostile-co-parenting-message.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-set-boundaries-in-co-parent-communication.html
+++ b/blog/how-to-set-boundaries-in-co-parent-communication.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-split-expenses-with-your-co-parent-without-fighting.html
+++ b/blog/how-to-split-expenses-with-your-co-parent-without-fighting.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-stop-co-parenting-arguments-over-text.html
+++ b/blog/how-to-stop-co-parenting-arguments-over-text.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-stop-co-parenting-conflict-from-taking-over-your-life.html
+++ b/blog/how-to-stop-co-parenting-conflict-from-taking-over-your-life.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-stop-your-co-parent-from-controlling-you-through-the-kids.html
+++ b/blog/how-to-stop-your-co-parent-from-controlling-you-through-the-kids.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/how-to-talk-to-your-kids-about-the-divorce-at-every-age.html
+++ b/blog/how-to-talk-to-your-kids-about-the-divorce-at-every-age.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/is-it-time-making-the-hard-decision-about-your-marriage.html
+++ b/blog/is-it-time-making-the-hard-decision-about-your-marriage.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/is-it-time-navigating-whether-to-stay-or-go.html
+++ b/blog/is-it-time-navigating-whether-to-stay-or-go.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/managing-anxiety-when-you-can-t-control-what-happens-at-the-other-house.html
+++ b/blog/managing-anxiety-when-you-can-t-control-what-happens-at-the-other-house.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/mindset-shift-divorced-coparents.html
+++ b/blog/mindset-shift-divorced-coparents.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/parallel-parenting-vs-co-parenting-what-s-the-difference.html
+++ b/blog/parallel-parenting-vs-co-parenting-what-s-the-difference.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/rebuilding-your-identity-after-divorce.html
+++ b/blog/rebuilding-your-identity-after-divorce.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/relocation-after-divorce-what-you-need-to-know-before-you-move.html
+++ b/blog/relocation-after-divorce-what-you-need-to-know-before-you-move.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/requesting-schedule-swaps-work-travel-strategic-approach.html
+++ b/blog/requesting-schedule-swaps-work-travel-strategic-approach.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/signs-your-child-is-struggling-with-the-divorce-and-what-to-do.html
+++ b/blog/signs-your-child-is-struggling-with-the-divorce-and-what-to-do.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/signs-your-co-parenting-situation-is-improving-even-when-it-doesn-t-feel-like-it.html
+++ b/blog/signs-your-co-parenting-situation-is-improving-even-when-it-doesn-t-feel-like-it.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/surprising-benefits-of-co-parenting-better-than-you-think.html
+++ b/blog/surprising-benefits-of-co-parenting-better-than-you-think.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/the-48-hour-rule-why-waiting-before-responding-changes-everything.html
+++ b/blog/the-48-hour-rule-why-waiting-before-responding-changes-everything.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/the-emotional-toll-of-co-parenting-with-a-difficult-ex.html
+++ b/blog/the-emotional-toll-of-co-parenting-with-a-difficult-ex.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/the-stepparent-s-role-in-co-parenting-boundaries-that-work.html
+++ b/blog/the-stepparent-s-role-in-co-parenting-boundaries-that-work.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/timing-your-divorce-when-to-consider-separation-around-life-events.html
+++ b/blog/timing-your-divorce-when-to-consider-separation-around-life-events.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/tone-in-text-co-parenting.html
+++ b/blog/tone-in-text-co-parenting.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/unexpected-silver-linings-hidden-benefits-co-parenting.html
+++ b/blog/unexpected-silver-linings-hidden-benefits-co-parenting.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/what-counts-as-a-shared-expense-in-co-parenting.html
+++ b/blog/what-counts-as-a-shared-expense-in-co-parenting.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/what-counts-as-high-conflict-co-parenting.html
+++ b/blog/what-counts-as-high-conflict-co-parenting.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/what-happens-when-you-violate-custody-order-legal-consequences.html
+++ b/blog/what-happens-when-you-violate-custody-order-legal-consequences.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/what-is-a-guardian-ad-litem-and-what-do-they-do.html
+++ b/blog/what-is-a-guardian-ad-litem-and-what-do-they-do.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/what-is-a-parenting-plan-and-do-you-need-one.html
+++ b/blog/what-is-a-parenting-plan-and-do-you-need-one.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/what-is-contempt-of-court-in-custody-cases.html
+++ b/blog/what-is-contempt-of-court-in-custody-cases.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/what-is-structured-co-parenting-communication.html
+++ b/blog/what-is-structured-co-parenting-communication.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/what-makes-co-parenting-communication-actually-work.html
+++ b/blog/what-makes-co-parenting-communication-actually-work.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/what-to-do-when-your-co-parent-badmouths-you-to-the-kids.html
+++ b/blog/what-to-do-when-your-co-parent-badmouths-you-to-the-kids.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/what-to-do-when-your-co-parent-brings-up-the-past-in-every-conversation.html
+++ b/blog/what-to-do-when-your-co-parent-brings-up-the-past-in-every-conversation.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/what-to-do-when-your-co-parent-refuses-to-communicate.html
+++ b/blog/what-to-do-when-your-co-parent-refuses-to-communicate.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/what-to-expect-in-family-court-a-co-parent-s-guide.html
+++ b/blog/what-to-expect-in-family-court-a-co-parent-s-guide.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/what-your-kids-experience-when-co-parents-can-t-communicate.html
+++ b/blog/what-your-kids-experience-when-co-parents-can-t-communicate.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/what-your-teenager-needs-from-you-during-and-after-divorce.html
+++ b/blog/what-your-teenager-needs-from-you-during-and-after-divorce.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/when-child-asks-which-parent-they-love-more.html
+++ b/blog/when-child-asks-which-parent-they-love-more.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/when-co-parenting-conflict-won-t-stop-knowing-when-to-get-help.html
+++ b/blog/when-co-parenting-conflict-won-t-stop-knowing-when-to-get-help.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/when-to-divorce-timing-separation-around-life-events.html
+++ b/blog/when-to-divorce-timing-separation-around-life-events.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/when-your-child-has-a-new-sibling-at-the-other-house.html
+++ b/blog/when-your-child-has-a-new-sibling-at-the-other-house.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/when-your-child-says-they-don-t-want-to-go-to-the-other-parent-s-house.html
+++ b/blog/when-your-child-says-they-don-t-want-to-go-to-the-other-parent-s-house.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/when-your-co-parent-undermines-your-parenting.html
+++ b/blog/when-your-co-parent-undermines-your-parenting.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/when-your-co-parent-uses-the-kids-as-messengers.html
+++ b/blog/when-your-co-parent-uses-the-kids-as-messengers.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/blog/why-co-parenting-feels-harder-than-it-should.html
+++ b/blog/why-co-parenting-feels-harder-than-it-should.html
@@ -160,6 +160,16 @@
       siteNavToggle.classList.toggle('open');
       siteNavRight.classList.toggle('open');
     });
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   }
 </script>
 

--- a/calculators/index.html
+++ b/calculators/index.html
@@ -303,6 +303,16 @@
       siteNavRight.classList.toggle('open');
     });
   }
+  // Track App Store clicks
+  document.addEventListener('click', function(e) {
+    var link = e.target.closest('a[href*="apps.apple.com"]');
+    if (link && typeof gtag === 'function') {
+      gtag('event', 'app_store_click', {
+        link_url: link.href,
+        link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+      });
+    }
+  });
 </script><!-- Hero Section -->
   <section class="calc-hero">
     <div class="container fade-in">

--- a/co-parent-communication/index.html
+++ b/co-parent-communication/index.html
@@ -382,9 +382,17 @@
       siteNavRight.classList.toggle('open');
     });
   }
+  // Track App Store clicks
+  document.addEventListener('click', function(e) {
+    var link = e.target.closest('a[href*="apps.apple.com"]');
+    if (link && typeof gtag === 'function') {
+      gtag('event', 'app_store_click', {
+        link_url: link.href,
+        link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+      });
+    }
+  });
 </script>
-
-<script src="/js/access-modal.js" defer></script>
 
 <script src="/js/access-modal.js" defer></script>
 

--- a/co-parenting-expenses/index.html
+++ b/co-parenting-expenses/index.html
@@ -137,6 +137,16 @@
       siteNavRight.classList.toggle('open');
     });
   }
+  // Track App Store clicks
+  document.addEventListener('click', function(e) {
+    var link = e.target.closest('a[href*="apps.apple.com"]');
+    if (link && typeof gtag === 'function') {
+      gtag('event', 'app_store_click', {
+        link_url: link.href,
+        link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+      });
+    }
+  });
 </script><!-- Hero -->
   <section class="lp-hero" id="main-content">
     <div class="container">

--- a/communication-styles/index.html
+++ b/communication-styles/index.html
@@ -1121,6 +1121,16 @@
       "url": "https://getclearly.app"
     }
   }
+  // Track App Store clicks
+  document.addEventListener('click', function(e) {
+    var link = e.target.closest('a[href*="apps.apple.com"]');
+    if (link && typeof gtag === 'function') {
+      gtag('event', 'app_store_click', {
+        link_url: link.href,
+        link_location: 'cta'
+      });
+    }
+  });
   </script>
 </body>
 </html>

--- a/coparenting-alignment-guide/index.html
+++ b/coparenting-alignment-guide/index.html
@@ -383,9 +383,17 @@
       siteNavRight.classList.toggle('open');
     });
   }
+  // Track App Store clicks
+  document.addEventListener('click', function(e) {
+    var link = e.target.closest('a[href*="apps.apple.com"]');
+    if (link && typeof gtag === 'function') {
+      gtag('event', 'app_store_click', {
+        link_url: link.href,
+        link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+      });
+    }
+  });
 </script>
-
-<script src="/js/access-modal.js" defer></script>
 
 <script src="/js/access-modal.js" defer></script>
 

--- a/custody-schedule-help/index.html
+++ b/custody-schedule-help/index.html
@@ -457,6 +457,16 @@
       siteNavRight.classList.toggle('open');
     });
   }
+  // Track App Store clicks
+  document.addEventListener('click', function(e) {
+    var link = e.target.closest('a[href*="apps.apple.com"]');
+    if (link && typeof gtag === 'function') {
+      gtag('event', 'app_store_click', {
+        link_url: link.href,
+        link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+      });
+    }
+  });
 </script><script>
   // Mobile menu toggle
   const navToggle = document.querySelector('.nav-toggle');

--- a/faq.html
+++ b/faq.html
@@ -90,9 +90,17 @@
       siteNavRight.classList.toggle('open');
     });
   }
+  // Track App Store clicks
+  document.addEventListener('click', function(e) {
+    var link = e.target.closest('a[href*="apps.apple.com"]');
+    if (link && typeof gtag === 'function') {
+      gtag('event', 'app_store_click', {
+        link_url: link.href,
+        link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+      });
+    }
+  });
 </script>
-
-<script src="/js/access-modal.js" defer></script>
 
 <script src="/js/access-modal.js" defer></script>
 

--- a/help.html
+++ b/help.html
@@ -78,9 +78,17 @@
       siteNavRight.classList.toggle('open');
     });
   }
+  // Track App Store clicks
+  document.addEventListener('click', function(e) {
+    var link = e.target.closest('a[href*="apps.apple.com"]');
+    if (link && typeof gtag === 'function') {
+      gtag('event', 'app_store_click', {
+        link_url: link.href,
+        link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+      });
+    }
+  });
 </script>
-
-<script src="/js/access-modal.js" defer></script>
 
 <script src="/js/access-modal.js" defer></script>
 

--- a/high-conflict-coparenting/index.html
+++ b/high-conflict-coparenting/index.html
@@ -279,6 +279,16 @@
       siteNavRight.classList.toggle('open');
     });
   }
+  // Track App Store clicks
+  document.addEventListener('click', function(e) {
+    var link = e.target.closest('a[href*="apps.apple.com"]');
+    if (link && typeof gtag === 'function') {
+      gtag('event', 'app_store_click', {
+        link_url: link.href,
+        link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+      });
+    }
+  });
 </script><!-- Hero -->
   <section class="lp-hero" id="main-content">
     <div class="container">

--- a/index.html
+++ b/index.html
@@ -1230,6 +1230,16 @@
         siteNavRight.classList.toggle('open');
       });
     }
+    // Track App Store clicks
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest('a[href*="apps.apple.com"]');
+      if (link && typeof gtag === 'function') {
+        gtag('event', 'app_store_click', {
+          link_url: link.href,
+          link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+        });
+      }
+    });
   </script>
 
   <!-- Structured Data - Organization -->

--- a/js/access-modal.js
+++ b/js/access-modal.js
@@ -171,11 +171,9 @@
         successView.style.display = 'block';
 
         // GA4 event tracking
-        window.dataLayer = window.dataLayer || [];
-        window.dataLayer.push({
-          'event': 'form_submit',
-          'form_name': 'waitlist_signup'
-        });
+        if (typeof gtag === 'function') {
+          gtag('event', 'form_submit', { form_name: 'waitlist_signup' });
+        }
 
       } catch (error) {
         console.error('Access request error:', error);

--- a/js/professional-modal.js
+++ b/js/professional-modal.js
@@ -206,11 +206,9 @@
         successView.style.display = 'block';
 
         // GA4 event tracking
-        window.dataLayer = window.dataLayer || [];
-        window.dataLayer.push({
-          'event': 'form_submit',
-          'form_name': 'professional_signup'
-        });
+        if (typeof gtag === 'function') {
+          gtag('event', 'form_submit', { form_name: 'professional_signup' });
+        }
 
       } catch (error) {
         console.error('Professional signup error:', error);

--- a/kids-and-divorce/index.html
+++ b/kids-and-divorce/index.html
@@ -279,6 +279,16 @@
       siteNavRight.classList.toggle('open');
     });
   }
+  // Track App Store clicks
+  document.addEventListener('click', function(e) {
+    var link = e.target.closest('a[href*="apps.apple.com"]');
+    if (link && typeof gtag === 'function') {
+      gtag('event', 'app_store_click', {
+        link_url: link.href,
+        link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+      });
+    }
+  });
 </script><!-- Hero -->
   <section class="lp-hero" id="main-content">
     <div class="container">

--- a/mediation-prep/index.html
+++ b/mediation-prep/index.html
@@ -134,6 +134,16 @@
       siteNavRight.classList.toggle('open');
     });
   }
+  // Track App Store clicks
+  document.addEventListener('click', function(e) {
+    var link = e.target.closest('a[href*="apps.apple.com"]');
+    if (link && typeof gtag === 'function') {
+      gtag('event', 'app_store_click', {
+        link_url: link.href,
+        link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+      });
+    }
+  });
 </script><!-- Hero -->
   <section class="lp-hero" id="main-content">
     <div class="container">

--- a/plan-builder/index.html
+++ b/plan-builder/index.html
@@ -5072,5 +5072,17 @@
     // ==========================================
     updateUI();
   </script>
+  <script>
+  // Track App Store clicks
+  document.addEventListener('click', function(e) {
+    var link = e.target.closest('a[href*="apps.apple.com"]');
+    if (link && typeof gtag === 'function') {
+      gtag('event', 'app_store_click', {
+        link_url: link.href,
+        link_location: 'cta'
+      });
+    }
+  });
+  </script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -78,9 +78,17 @@
       siteNavRight.classList.toggle('open');
     });
   }
+  // Track App Store clicks
+  document.addEventListener('click', function(e) {
+    var link = e.target.closest('a[href*="apps.apple.com"]');
+    if (link && typeof gtag === 'function') {
+      gtag('event', 'app_store_click', {
+        link_url: link.href,
+        link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+      });
+    }
+  });
 </script>
-
-<script src="/js/access-modal.js" defer></script>
 
 <script src="/js/access-modal.js" defer></script>
 

--- a/professionals.html
+++ b/professionals.html
@@ -356,9 +356,17 @@
       siteNavRight.classList.toggle('open');
     });
   }
+  // Track App Store clicks
+  document.addEventListener('click', function(e) {
+    var link = e.target.closest('a[href*="apps.apple.com"]');
+    if (link && typeof gtag === 'function') {
+      gtag('event', 'app_store_click', {
+        link_url: link.href,
+        link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+      });
+    }
+  });
 </script>
-
-<script src="/js/access-modal.js" defer></script>
 
 <script src="/js/access-modal.js" defer></script>
 

--- a/terms.html
+++ b/terms.html
@@ -78,9 +78,17 @@
       siteNavRight.classList.toggle('open');
     });
   }
+  // Track App Store clicks
+  document.addEventListener('click', function(e) {
+    var link = e.target.closest('a[href*="apps.apple.com"]');
+    if (link && typeof gtag === 'function') {
+      gtag('event', 'app_store_click', {
+        link_url: link.href,
+        link_location: link.closest('header,footer,.final-cta,.hero') ? link.closest('header') ? 'header' : link.closest('footer') ? 'footer' : 'cta' : 'body'
+      });
+    }
+  });
 </script>
-
-<script src="/js/access-modal.js" defer></script>
 
 <script src="/js/access-modal.js" defer></script>
 


### PR DESCRIPTION
## Summary
- **App Store click tracking**: Added `app_store_click` gtag event to all 121 pages — fires whenever someone clicks any App Store link, with `link_location` param (header/footer/cta/body)
- **Fixed broken event tracking**: Converted `dataLayer.push` to `gtag('event', ...)` in access-modal.js and professional-modal.js so `form_submit` events actually reach GA4 (previously silently lost without GTM)
- **GA4 admin changes** (already applied):
  - Data retention: 2 months → 14 months
  - Marked `click` and `form_start` as key events (conversions)
  - `app_store_click` and `form_submit` will auto-register as events once they fire

## Test plan
- [x] All 121 HTML files contain `app_store_click` tracking code
- [x] `gtag()` calls replace all `dataLayer.push` in modal JS files
- [x] GA4 key events configured in admin
- [ ] Verify `app_store_click` event appears in GA4 Realtime after clicking an App Store link

🤖 Generated with [Claude Code](https://claude.com/claude-code)