### PR TITLE
Reconcile FAQ structured data with visible questions

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -189,6 +189,11 @@
       <h2 style="margin-top: 48px;">Getting Started</h2>
 
       <div class="faq-item">
+        <h3>How much does Clearly cost?</h3>
+        <p>Clearly is $290 per year per parent (billed annually) or $29.99 per month per parent (billed monthly). Each parent subscribes separately, and a free trial is included.</p>
+      </div>
+
+      <div class="faq-item">
         <h3>How do I get access to Clearly?</h3>
         <p>Clearly is available now on the App Store for iPhone and iPad. Download it and get started in minutes.</p>
       </div>
@@ -279,7 +284,7 @@
         "name": "Why do co-parents need an app?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Text messages and emails can get lost, misunderstood, or escalate into conflict. Co-parenting apps provide a structured, neutral space for communication that keeps the focus on the kids. They also create a record of agreements and schedules that both parents can reference."
+          "text": "Text messages and emails can get lost, misunderstood, or escalate into conflict. Co-parenting apps provide a structured, neutral space for communication that keeps the focus on the kids. They also create a record of agreements and schedules that both parents can reference — reducing confusion and \"he said, she said\" situations."
         }
       },
       {
@@ -287,7 +292,7 @@
         "name": "How is a co-parenting app different from texting?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Unlike texting, co-parenting apps are purpose-built for shared parenting. They organize conversations by topic, track custody schedules, calculate expense splits, and create documentation that can be referenced later."
+          "text": "Unlike texting, co-parenting apps are purpose-built for shared parenting. They organize conversations by topic, track custody schedules, calculate expense splits, and create documentation that can be referenced later. Many also include features to help keep communication civil and focused on the children."
         }
       },
       {
@@ -295,7 +300,7 @@
         "name": "What features should I look for in a co-parenting app?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "The best co-parenting apps include: a shared custody calendar with holiday scheduling, structured communication tools, expense tracking with split calculations, schedule swap requests, calendar sync, and the ability to export records."
+          "text": "The best co-parenting apps include: a shared custody calendar with holiday scheduling, structured communication tools, expense tracking with split calculations, schedule swap requests, calendar sync (Apple, Google), and the ability to export records. Some apps also offer AI assistance to help keep messages neutral and constructive."
         }
       },
       {
@@ -303,7 +308,7 @@
         "name": "What makes Clearly different from other co-parenting apps?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Clearly is built around helping conversations reach resolution. Our structured Topics system is inspired by the Harvard Negotiation Framework. We also use AI to help rewrite messages in a neutral tone."
+          "text": "Clearly is built around one principle: helping conversations reach resolution. Our structured \"Topics\" system is inspired by the Harvard Negotiation Framework, guiding discussions toward outcomes instead of endless back-and-forth. We also use AI to help rewrite messages in a neutral tone — so your co-parent hears what you need to say, not how you're feeling in the moment."
         }
       },
       {
@@ -311,7 +316,39 @@
         "name": "How does Clearly help reduce conflict?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Clearly uses AI to transform emotionally charged messages into neutral summaries. You write what you feel, review the suggested rewrite, and send the neutral version. Your original words stay private."
+          "text": "Clearly uses AI to transform emotionally charged messages into neutral summaries. You write what you feel, review the suggested rewrite, and send the neutral version. Your original words stay private. This helps conversations stay productive and focused on what actually matters — your kids."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can Clearly handle complex custody schedules?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. Clearly supports common custody patterns (50/50, 2-2-3, every other weekend, and more) as well as fully custom schedules. Holiday custody with odd/even year rotations is built in. You can also request schedule swaps and sync everything to your phone's calendar."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How does expense tracking work?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Set your expense split ratio once (50/50, 60/40, or any custom split based on your agreement). When either parent logs an expense, Clearly automatically calculates who owes what. You can attach receipts and track reimbursements — no spreadsheets required."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Is Clearly available on Android?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Clearly is currently available on iOS (iPhone and iPad). Android support is on our roadmap. Sign up for our newsletter to be notified when Android launches."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can I export records from Clearly?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. You can export communication records, schedules, and expenses as PDF or CSV files. Exports include timestamps and are suitable for personal records or sharing with attorneys and mediators if needed."
         }
       },
       {
@@ -320,6 +357,22 @@
         "acceptedAnswer": {
           "@type": "Answer",
           "text": "Clearly is $290 per year per parent (billed annually) or $29.99 per month per parent (billed monthly). Each parent subscribes separately, and a free trial is included."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do I get access to Clearly?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Clearly is available now on the App Store for iPhone and iPad. Download it and get started in minutes."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do I get my co-parent to join?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "After signing up, you'll receive a Family Join Code in your settings. Share this code with your co-parent so they can connect to your shared family when they create their account. Once connected, your schedules and conversations sync automatically."
         }
       },
       {


### PR DESCRIPTION
## FAQ structured‑data reconciliation

The FAQ page's `FAQPage` JSON‑LD didn't match its visible content — it carried a non‑visible pricing Q&A and omitted several on‑page questions. Google's guidelines require FAQPage markup to reflect what users actually see, so mismatched markup risks the rich result being ignored (or flagged).

**Changes (one file, `faq.html`):**
- Rebuilt the JSON‑LD `mainEntity` to mirror the **visible FAQ exactly** — 14 Q&As, verbatim answer text.
- Added a **visible "How much does Clearly cost?"** item ($290/yr, $29.99/mo) so pricing keeps legitimate structured‑data coverage instead of being dropped.

**Verified:** 14 visible questions == 14 JSON‑LD questions (exact, in order); `npm test` (seo‑check + link‑check) passing.

Only `faq.html` changes; no other pages affected. Production untouched; not merged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015EH3P6Am9qAZ2UPeStWHwA)_